### PR TITLE
feat: add IAM auth support (required for stack config templating as of atmos 1.86.2)

### DIFF
--- a/.github/workflows/test-matrix-2-levels.yml
+++ b/.github/workflows/test-matrix-2-levels.yml
@@ -7,6 +7,10 @@ on:
 #  pull_request: {}
   workflow_dispatch: {}
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-matrix-2-levels.yml
+++ b/.github/workflows/test-matrix-2-levels.yml
@@ -21,10 +21,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - shell: bash
+        run: |
+          mkdir -p ${{ runner.temp }}
+          cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
+          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
+
       - uses: ./
         id: current
         with:
-          atmos-config-path: "./tests"
+          atmos-config-path: "${{ runner.temp }}"
           select-filter: '.settings.github.actions_enabled // false'
           nested-matrices-count: '2'
 

--- a/.github/workflows/test-matrix-3-levels.yml
+++ b/.github/workflows/test-matrix-3-levels.yml
@@ -7,6 +7,10 @@ on:
 #  pull_request: {}
   workflow_dispatch: {}
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-matrix-3-levels.yml
+++ b/.github/workflows/test-matrix-3-levels.yml
@@ -22,10 +22,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - shell: bash
+        run: |
+          mkdir -p ${{ runner.temp }}
+          cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
+          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
+
       - uses: ./
         id: current
         with:
-          atmos-config-path: "./tests"
+          atmos-config-path: "${{ runner.temp }}"
           select-filter: '.settings.github.actions_enabled // false'
           nested-matrices-count: '3'
 

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -7,6 +7,10 @@ on:
 #  pull_request: {}
   workflow_dispatch: {}
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -22,10 +22,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - shell: bash
+        run: |
+          mkdir -p ${{ runner.temp }}
+          cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
+          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
+
       - uses: ./
         id: current
         with:
-          atmos-config-path: "./tests"
+          atmos-config-path: "${{ runner.temp }}"
 
     outputs:
       selected-components: "${{ steps.current.outputs.selected-components }}"

--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,8 @@ runs:
         echo "terraform-version=$(atmos describe config -f json | jq -r '.integrations.github.gitops["terraform-version"]')" >> $GITHUB_OUTPUT        
         echo "group-by=$(atmos describe config -f json | jq -r '.integrations.github.gitops.matrix["group-by"]')" >> $GITHUB_OUTPUT
         echo "sort-by=$(atmos describe config -f json | jq -r '.integrations.github.gitops.matrix["sort-by"]')" >> $GITHUB_OUTPUT        
+        echo "aws-region=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].region')" >> $GITHUB_OUTPUT
+        echo "terraform-plan-role=$(atmos describe config -f json | jq -r '.integrations.github.gitops.role.plan')" >> $GITHUB_OUTPUT
 
     - name: Install Terraform
       if: ${{ steps.config.outputs.terraform-version != '' && steps.config.outputs.terraform-version != 'null' }}
@@ -98,6 +100,14 @@ runs:
         config: |-
           opentofu/opentofu: 
             tag: ${{ startsWith(steps.config.outputs.opentofu-version, 'v') && steps.config.outputs.opentofu-version || format('v{0}', steps.config.outputs.opentofu-version) }}
+
+    - name: Configure Plan AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: ${{ steps.config.outputs.aws-region }}
+        role-to-assume: ${{ steps.config.outputs.terraform-plan-role }}
+        role-session-name: "atmos-terraform-plan-gitops"
+        mask-aws-account-id: "no"
 
     - name: Filter Components
       id: selected-components

--- a/tests/atmos.yaml
+++ b/tests/atmos.yaml
@@ -70,7 +70,7 @@ integrations:
         table: cptest-core-ue2-auto-gitops-plan-storage
         role: arn:aws:iam::xxxxxxxxxxxx:role/cptest-core-ue2-auto-gitops-gha
       role:
-        plan: arn:aws:iam::yyyyyyyyyyyy:role/cptest-core-gbl-identity-gitops
+        plan: __PLAN_ROLE__
         apply: arn:aws:iam::yyyyyyyyyyyy:role/cptest-core-gbl-identity-gitops
       matrix:
         sort-by: .stack_slug


### PR DESCRIPTION
## what

* Add IAM auth support

## why

* IAM auth is required for stack config templating as of atmos `1.86.2`

## references

* https://github.com/cloudposse/atmos/releases/tag/v1.86.2

## Break compatibility
* The action now locked on AWS, if you are using the action with another cloud provider pls use version `v3`