### PR TITLE
Add process functions option to Github Action parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The following configuration fields moved to the `atmos.yaml` configuration file.
 | `enable-infracost`       |  `integrations.github.gitops.infracost-enabled` |
 | `sort-by`                |  `integrations.github.gitops.matrix.sort-by`    |
 | `group-by`               |  `integrations.github.gitops.matrix.group-by`   |
+| `process-functions`      |  `integrations.github.gitops.matrix.process-functions`   |
 
 
 For example, to migrate from `v1` to `v2`, you should have something similar to the following in your `atmos.yaml`:

--- a/README.yaml
+++ b/README.yaml
@@ -184,6 +184,7 @@ usage: |
   | `enable-infracost`       |  `integrations.github.gitops.infracost-enabled` |
   | `sort-by`                |  `integrations.github.gitops.matrix.sort-by`    |
   | `group-by`               |  `integrations.github.gitops.matrix.group-by`   |
+  | `process-functions`      |  `integrations.github.gitops.matrix.process-functions`   |
   
   
   For example, to migrate from `v1` to `v2`, you should have something similar to the following in your `atmos.yaml`:

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
     required: false
     description: 'Number of nested matrices that should be returned as the output (from 1 to 3)'
     default: "2"
+  process-functions:
+    required: false
+    description: 'Whether to process atmos functions'
+    default: true
 outputs:
   selected-components:
     description: Selected GitOps components
@@ -136,8 +140,14 @@ runs:
             })
           ) | map(.) | flatten                                          ## Reduce to flat array
       run: |
-        atmos describe stacks --format json | jq -ce "${JQUERY}" > components.json
-
+        base_cmd= "atmos describe stacks --format json"
+        
+        if [[ "${{ inputs.process-functions }}" == "false" ]]; then
+          base_cmd+=" --process-functions=false"
+        fi       
+        
+        final_cmd= base_cmd+=" | jq -ce "${JQUERY}" > components.json" 
+        eval "$final_cmd"
         components=$(cat components.json)
         echo "Selected components: $components"
         printf "%s" "components=$components" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -140,14 +140,7 @@ runs:
             })
           ) | map(.) | flatten                                          ## Reduce to flat array
       run: |
-        base_cmd= "atmos describe stacks --format json"
-        
-        if [[ "${{ inputs.process-functions }}" == "false" ]]; then
-          base_cmd+=" --process-functions=false"
-        fi       
-        
-        final_cmd= base_cmd+=" | jq -ce "${JQUERY}" > components.json" 
-        eval "$final_cmd"
+        atmos describe stacks --process-functions=${{ inputs.atmos-process-function }} --format json | jq -ce "${JQUERY}" > components.json
         components=$(cat components.json)
         echo "Selected components: $components"
         printf "%s" "components=$components" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -140,11 +140,14 @@ runs:
             })
           ) | map(.) | flatten                                          ## Reduce to flat array
       run: |
-        atmos describe stacks --process-functions=${{ inputs.atmos-process-function }} --format json | jq -ce "${JQUERY}" > components.json
+        process_function_arg=""
+        if [ "${{ inputs.process-function }}" == "false" ]; then
+          process_function_arg="--process-functions=false"
+        fi
+        atmos describe stacks $process_function_arg --format json | jq -ce "${JQUERY}" > components.json
         components=$(cat components.json)
         echo "Selected components: $components"
-        printf "%s" "components=$components" >> $GITHUB_OUTPUT
-
+        printf "%s" "components=$components" >> $GITHUB_OUTPUT    
     - uses: cloudposse/github-action-matrix-extended@v0
       id: matrix
       with:

--- a/action.yml
+++ b/action.yml
@@ -141,7 +141,7 @@ runs:
           ) | map(.) | flatten                                          ## Reduce to flat array
       run: |
         process_function_arg=""
-        if [ "${{ inputs.process-function }}" == "false" ]; then
+        if [ "${{ inputs.process-functions }}" == "false" ]; then
           process_function_arg="--process-functions=false"
         fi
         atmos describe stacks $process_function_arg --format json | jq -ce "${JQUERY}" > components.json

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -11,6 +11,7 @@
 | jq-version | The version of jq to install if install-jq is true | 1.6 | false |
 | nested-matrices-count | Number of nested matrices that should be returned as the output (from 1 to 3) | 2 | false |
 | select-filter | jq query that will be used to select atmos components | . | false |
+| process-functions | Whether to process functions | true | false |
 
 
 ## Outputs


### PR DESCRIPTION
## what
* Added process-functions input

## why
* When process-functions is false, we can avoid processing the yaml functions. Values retrieved via the !store commands don't always need to be retrieved when calling atmos describe affected so exposing this flag allows it to be toggled off.

## references
* https://atmos.tools/cli/commands/describe/component/#:~:text=no-,%2D%2Dprocess%2Dfunctions,-Enable/disable%20processing
* [Similar PR in github-action-atmos-affected-stacks](https://github.com/cloudposse/github-action-atmos-affected-stacks/pull/64)

