### PR TITLE
Replace Makefile with atmos.yaml

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -291,7 +291,7 @@ usage: |
   Please note that the `atmos-gitops-config-path` is not the same file as the `atmos-config-path`.
 
 
-include:
+include: []
 
 contributors:
   - name: "Zinovii Dmytriv"


### PR DESCRIPTION
## what
- Remove `Makefile`
- Add `atmos.yaml`

## why
- Replace `build-harness` with `atmos` for readme genration

## References
* DEV-3229 Migrate from build-harness to atmos
