### PR TITLE
chore: upgrade actions to Node 24 runtime (SHA-pinned)

### DIFF
--- a/.github/workflows/test-matrix-2-levels.yml
+++ b/.github/workflows/test-matrix-2-levels.yml
@@ -32,7 +32,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - shell: bash
         run: |
@@ -55,18 +55,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '[{"component":"test-2","stack":"core-ue2-auto","stack_slug":"core-ue2-auto-test-2"},{"component":"test-4","stack":"plat-ue2-dev","stack_slug":"plat-ue2-dev-test-4"},{"component":"test-5","stack":"plat-ue2-sandbox","stack_slug":"plat-ue2-sandbox-test-5"}]'
           actual: "${{ needs.test.outputs.selected-components }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '{"include":['
           actual: "${{ needs.test.outputs.matrix }}"
           comparison: contains
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '{"include":[{"name":"core-auto","items":"{\"include\":[{\"component\":\"test-2\",\"stack\":\"core-ue2-auto\",\"stack_slug\":\"core-ue2-auto-test-2\"}]}"},{"name":"plat-dev","items":"{\"include\":[{\"component\":\"test-4\",\"stack\":\"plat-ue2-dev\",\"stack_slug\":\"plat-ue2-dev-test-4\"}]}"},{"name":"plat-sandbox","items":"{\"include\":[{\"component\":\"test-5\",\"stack\":\"plat-ue2-sandbox\",\"stack_slug\":\"plat-ue2-sandbox-test-5\"}]}"}]}'
           actual: "${{ needs.test.outputs.matrix }}"

--- a/.github/workflows/test-matrix-3-levels.yml
+++ b/.github/workflows/test-matrix-3-levels.yml
@@ -32,7 +32,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - shell: bash
         run: |
@@ -55,18 +55,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '[{"component":"test-2","stack":"core-ue2-auto","stack_slug":"core-ue2-auto-test-2"},{"component":"test-4","stack":"plat-ue2-dev","stack_slug":"plat-ue2-dev-test-4"},{"component":"test-5","stack":"plat-ue2-sandbox","stack_slug":"plat-ue2-sandbox-test-5"}]'
           actual: "${{ needs.test.outputs.selected-components }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '{"include":['
           actual: "${{ needs.test.outputs.matrix }}"
           comparison: contains
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '{"include":[{"name":"core-auto","items":"{\"include\":[{\"name\":\"core-ue2-auto-test-2 - core-ue2-auto-test-2\",\"items\":\"{\\\"include\\\":[{\\\"component\\\":\\\"test-2\\\",\\\"stack\\\":\\\"core-ue2-auto\\\",\\\"stack_slug\\\":\\\"core-ue2-auto-test-2\\\"}]}\"}]}"},{"name":"plat-dev","items":"{\"include\":[{\"name\":\"plat-ue2-dev-test-4 - plat-ue2-dev-test-4\",\"items\":\"{\\\"include\\\":[{\\\"component\\\":\\\"test-4\\\",\\\"stack\\\":\\\"plat-ue2-dev\\\",\\\"stack_slug\\\":\\\"plat-ue2-dev-test-4\\\"}]}\"}]}"},{"name":"plat-sandbox","items":"{\"include\":[{\"name\":\"plat-ue2-sandbox-test-5 - plat-ue2-sandbox-test-5\",\"items\":\"{\\\"include\\\":[{\\\"component\\\":\\\"test-5\\\",\\\"stack\\\":\\\"plat-ue2-sandbox\\\",\\\"stack_slug\\\":\\\"plat-ue2-sandbox-test-5\\\"}]}\"}]}"}]}'
           actual: "${{ needs.test.outputs.matrix }}"

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -32,7 +32,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - shell: bash
         run: |
@@ -53,18 +53,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '[{"component":"test-1","stack":"core-ue2-auto","stack_slug":"core-ue2-auto-test-1"},{"component":"test-2","stack":"core-ue2-auto","stack_slug":"core-ue2-auto-test-2"},{"component":"test-3","stack":"plat-ue2-dev","stack_slug":"plat-ue2-dev-test-3"},{"component":"test-4","stack":"plat-ue2-dev","stack_slug":"plat-ue2-dev-test-4"},{"component":"test-5","stack":"plat-ue2-sandbox","stack_slug":"plat-ue2-sandbox-test-5"}]'
           actual: "${{ needs.test.outputs.selected-components }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '{"include":['
           actual: "${{ needs.test.outputs.matrix }}"
           comparison: contains
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '{"include":[{"name":"core-auto","items":"{\"include\":[{\"component\":\"test-1\",\"stack\":\"core-ue2-auto\",\"stack_slug\":\"core-ue2-auto-test-1\"},{\"component\":\"test-2\",\"stack\":\"core-ue2-auto\",\"stack_slug\":\"core-ue2-auto-test-2\"}]}"},{"name":"plat-dev","items":"{\"include\":[{\"component\":\"test-3\",\"stack\":\"plat-ue2-dev\",\"stack_slug\":\"plat-ue2-dev-test-3\"},{\"component\":\"test-4\",\"stack\":\"plat-ue2-dev\",\"stack_slug\":\"plat-ue2-dev-test-4\"}]}"},{"name":"plat-sandbox","items":"{\"include\":[{\"component\":\"test-5\",\"stack\":\"plat-ue2-sandbox\",\"stack_slug\":\"plat-ue2-sandbox-test-5\"}]}"}]}'
           actual: "${{ needs.test.outputs.matrix }}"

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout source code at current commit"
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository

--- a/action.yml
+++ b/action.yml
@@ -55,11 +55,11 @@ runs:
   using: "composite"
   steps:
     - name: Install Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       if: ${{ inputs.skip-checkout != 'true' }}    
       with:
         ref: ${{ inputs.head-ref }}
@@ -71,7 +71,7 @@ runs:
           jqlang/jq: jq-${{ inputs.jq-version }}
 
     - name: Install Atmos
-      uses: cloudposse/github-action-setup-atmos@v2
+      uses: cloudposse/github-action-setup-atmos@60878d48037763f759aedee74e9cc0c2dc88e9ec # v3.5.0
       env:
        ATMOS_CLI_CONFIG_PATH: ${{inputs.atmos-config-path}}
       with:
@@ -96,7 +96,7 @@ runs:
 
     - name: Install Terraform
       if: ${{ steps.config.outputs.terraform-version != '' && steps.config.outputs.terraform-version != 'null' }}
-      uses: hashicorp/setup-terraform@v3
+      uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       with:
         terraform_version: ${{ steps.config.outputs.terraform-version }}
         terraform_wrapper: false
@@ -111,7 +111,7 @@ runs:
             tag: ${{ startsWith(steps.config.outputs.opentofu-version, 'v') && steps.config.outputs.opentofu-version || format('v{0}', steps.config.outputs.opentofu-version) }}
 
     - name: Configure Plan AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
       if: ${{ steps.config.outputs.aws-region != '' &&
         steps.config.outputs.aws-region != 'null' &&
         steps.config.outputs.terraform-plan-role != '' &&
@@ -120,7 +120,7 @@ runs:
         aws-region: ${{ steps.config.outputs.aws-region }}
         role-to-assume: ${{ steps.config.outputs.terraform-plan-role }}
         role-session-name: "atmos-terraform-plan-gitops"
-        mask-aws-account-id: "no"
+        mask-aws-account-id: "false"
 
     - name: Filter Components
       id: selected-components


### PR DESCRIPTION
## what

* Bump GitHub Actions references in the workflows to versions running on the Node 24 runtime,
  SHA-pinned with precise version comments:
  * `actions/checkout@v4` → `@3d3c42e5...` `# v7.0.1`
  * `actions/setup-node@v4` → `@82076278...` `# v7.0.0`
  * `nick-fields/assert-action@v2` → `@0efd6166...` `# v4.0.1`
  * `cloudposse/github-action-setup-atmos@v2` → `@60878d48...` `# v3.5.0`
  * `hashicorp/setup-terraform@v3` → `@dfe3c3f8...` `# v4.0.1`
  * `aws-actions/configure-aws-credentials@v4` → `@e6de0542...` `# v6.2.3`
* `aws-actions/configure-aws-credentials` v5+ requires strict booleans: rewrote
  `mask-aws-account-id: "no"` → `"false"` in `action.yml`

## why

* GitHub is deprecating the Node 20 runtime; affected workflows emit a deprecation warning and
  are already being force-migrated to Node 24
* SHA pinning with a verified tag comment makes the upgrade deliberate and supply-chain-safe,
  matching the org's direction in cloudposse/.github#261
* Every pinned SHA was verified against its upstream tag

Supersedes #53
Supersedes #52
Supersedes #51
Supersedes #49
Supersedes #48
Supersedes #47

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## still on Node 20

* `cloudposse-github-actions/install-gh-releases@v1` — no Node 24 release exists yet
